### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/content/articles.bib
+++ b/content/articles.bib
@@ -90,7 +90,7 @@
   Pages                    = {E29-E40},
   Volume                   = {80},
   Doi                      = {10.1190/geo2014-0214.1},
-  Eprint                   = {http://dx.doi.org/10.1190/geo2014-0214.1},
+  Eprint                   = {https://doi.org/10.1190/geo2014-0214.1},
   Owner                    = {fwagner},
   Timestamp                = {2015.01.17},
   Url                      = {http://gfzpublic.gfz-potsdam.de/pubman/item/escidoc:838894:3/component/escidoc:860894/838894.pdf}

--- a/content/pages/thesis.rst
+++ b/content/pages/thesis.rst
@@ -28,7 +28,7 @@ storage at Ketzin, Germany.
 .. image:: /static/diss.png
     :width: 90%
     :alt: Cover page
-    :target: http://dx.doi.org/10.3929/ethz-a-010636965
+    :target: https://doi.org/10.3929/ethz-a-010636965
 
 .. raw:: html
 
@@ -38,4 +38,4 @@ storage at Ketzin, Germany.
 
     Wagner, Florian Michael. New developments in electrical resistivity imaging
     with applications to geological CO\ :sub:`2` storage. ETH-Zürich (2016).
-    http://dx.doi.org/10.3929/ethz-a-010636965 :icon:`file-pdf-o` :icon:`openaccess`
+    https://doi.org/10.3929/ethz-a-010636965 :icon:`file-pdf-o` :icon:`openaccess`

--- a/generate_bib.py
+++ b/generate_bib.py
@@ -130,7 +130,7 @@ for year in articles:
             f.write(article["volume"] + ", ")
             f.write(article["pages"] + ", ")
             if len(article["doi"]) > 3:
-                f.write("`DOI:" + article["doi"] + " <http://dx.doi.org/" +
+                f.write("`DOI:" + article["doi"] + " <https://doi.org/" +
                         article["doi"] + ">`_")
         else:
             print("No volume info found for", article)
@@ -175,7 +175,7 @@ for year in conference:
         else:
             f.write("*Conference Proceeding*")
         if 'doi' in article:
-            f.write(", `DOI:" + article["doi"] + " <http://dx.doi.org/" +
+            f.write(", `DOI:" + article["doi"] + " <https://doi.org/" +
                     article["doi"] + ">`_")
 
         if "note" in article:


### PR DESCRIPTION
Guten Tag Herr Wagner,

da die DOI-Foundation inzwischen einen [neuen, verschlüsselten Resolver empfiehlt](https://www.doi.org/doi_handbook/3_Resolution.html#3.8), hier ein paar Änderungsvorschläge für die DOI-URLs, sowie den Code, der neue generiert.

Viele Grüße!